### PR TITLE
feat: move magic number validation to its place

### DIFF
--- a/src/core/class_file.go
+++ b/src/core/class_file.go
@@ -116,7 +116,6 @@ const (
 )
 
 var (
-	ErrInvalidMagicNumber      = fmt.Errorf("invalid magic number")
 	ErrInvalidConstantPoolSize = fmt.Errorf("invalid constant pool size")
 	Tags                       = map[uint8]string{
 		CONSTANT_Class:              "CONSTANT_Class",
@@ -148,10 +147,6 @@ func ClassFileFromReader(reader *bytes.Reader) (ClassFile, error) {
 	magic, err := bigEndianReader.ReadUint32()
 	if err != nil {
 		return classFile, err
-	}
-
-	if magic != MagicNumber {
-		return classFile, ErrInvalidMagicNumber
 	}
 
 	classFile.Magic = magic
@@ -281,7 +276,19 @@ func ClassFileFromReader(reader *bytes.Reader) (ClassFile, error) {
 }
 
 func (c *ClassFile) Validate() error {
+	if err := c.validateMagicNumber(); err != nil {
+		return err
+	}
+
 	// TODO: implement
+	return nil
+}
+
+func (c *ClassFile) validateMagicNumber() error {
+	if c.Magic != MagicNumber {
+		return fmt.Errorf("invalid magic number: 0x%x", c.Magic)
+	}
+
 	return nil
 }
 

--- a/src/core/class_file_test.go
+++ b/src/core/class_file_test.go
@@ -7,12 +7,19 @@ import (
 	"github.com/Gustrb/jbm/src/core"
 )
 
-func TestItShouldFailIfTheMagicNumberIsNotValid(t *testing.T) {
-	b := []byte{0x00, 0xFE, 0xBA, 0xBE}
+func TestShouldValidateMagicNumber(t *testing.T) {
+	cf := core.ClassFile{Magic: 0xCAFEBABE}
 
-	_, err := core.ClassFileFromReader(bytes.NewReader(b))
-	if err != core.ErrInvalidMagicNumber {
-		t.Errorf("Expected ErrInvalidMagicNumber, got %v", err)
+	if err := cf.Validate(); err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+}
+
+func TestShouldFailIfMagicNumberIsInvalid(t *testing.T) {
+	cf := core.ClassFile{Magic: 0xDEADBEEF}
+
+	if err := cf.Validate(); err.Error() != "invalid magic number: 0xdeadbeef" {
+		t.Errorf("Expected 'invalid magic number 0xdeadbeef', got %v", err)
 	}
 }
 


### PR DESCRIPTION
Adding validation to the `MagicField` part of the `ClassFile` struct

We had this validation but it was scattered around the parse file, now I put it in the correct place and also added better testing :P

Relates to the: "Magic number validation, if the magic number is not 0xCAFEBABE we should return an error" task of #1 